### PR TITLE
Correct file path for predictions

### DIFF
--- a/vui_notebook.ipynb
+++ b/vui_notebook.ipynb
@@ -758,7 +758,7 @@
     "get_predictions(index=0, \n",
     "                partition='train',\n",
     "                input_to_softmax=final_model(), \n",
-    "                model_path='model_end.h5')"
+    "                model_path='results/model_end.h5')"
    ]
   },
   {
@@ -779,7 +779,7 @@
     "get_predictions(index=0, \n",
     "                partition='validation',\n",
     "                input_to_softmax=final_model(), \n",
-    "                model_path='model_end.h5')"
+    "                model_path='results/model_end.h5')"
    ]
   },
   {


### PR DESCRIPTION
Predictions are trying to retrieve model_end.h5, which is stored in the "results/" folder.
If not specifying the folder to properly load the .h5 file it leads to a "file not found" error.

Thought correcting the file path is better than saving .h5 files in the main folder. 