### PR TITLE
Remove `implementation` argument to `SimpleRNN`

### DIFF
--- a/sample_models.py
+++ b/sample_models.py
@@ -56,7 +56,7 @@ def cnn_rnn_model(input_dim, filters, kernel_size, conv_stride,
     bn_cnn = BatchNormalization(name='bn_conv_1d')(conv_1d)
     # Add a recurrent layer
     simp_rnn = SimpleRNN(units, activation='relu',
-        return_sequences=True, implementation=2, name='rnn')(bn_cnn)
+        return_sequences=True, name='rnn')(bn_cnn)
     # TODO: Add batch normalization
     bn_rnn = ...
     # TODO: Add a TimeDistributed(Dense(output_dim)) layer


### PR DESCRIPTION
The `implementation` argument in `SimpleRNN` has been deprecated. This warning prints when running this in the Udacity Workspace:
```
Error:
/opt/conda/lib/python3.6/site-packages/keras/layers/recurrent.py:1004: UserWarning: The `implementation` argument in `SimpleRNN` has been deprecated. Please remove it from your layer call.
  warnings.warn('The `implementation` argument '
```